### PR TITLE
Add version param to CLI and render

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Simple, opinionated, Github changelog generator written in Haskell.
 
 **Please Note:** This project is a work in progress.
 
+## Usage
+
+```
+gh-delta - changelog generator
+
+Usage: gh-delta [--auth ARG] --owner ARG --repo ARG --since ARG [--version ARG]
+  Simple, opinionated, Github changelog generator written in Haskell
+
+Available options:
+  -h,--help                Show this help text
+  --auth ARG               Personal access token
+  --owner ARG              Repository owner
+  --repo ARG               Repository name
+  --since ARG              Since SHA
+  --version ARG            Version for changelog entry
+```
+
 ## Example
 
 ```

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,8 @@ import           Control.Applicative ((<|>))
 import           Data.Function       ((&))
 import           Lib                 (DeltaParams, defaultDeltaParams, generate,
                                       setDeltaParamsAuth, setDeltaParamsOwner,
-                                      setDeltaParamsRepo, setDeltaParamsSince)
+                                      setDeltaParamsRepo, setDeltaParamsSince,
+                                      setDeltaParamsVersion)
 import           Options.Applicative (Parser, ParserInfo, execParser, fullDesc,
                                       header, help, helper, info, long,
                                       optional, progDesc, strOption, (<>))
@@ -14,10 +15,11 @@ import           System.Environment  (lookupEnv)
 
 data CLIOpts =
        CLIOpts
-         { cliAuth  :: Maybe String
-         , cliOwner :: String
-         , cliRepo  :: String
-         , cliSince :: String
+         { cliAuth    :: Maybe String
+         , cliOwner   :: String
+         , cliRepo    :: String
+         , cliSince   :: String
+         , cliVersion :: Maybe String
          }
 
 cliOpts :: ParserInfo CLIOpts
@@ -37,6 +39,8 @@ cliOptsParser =
                          <> help "Repository name")
           <*> strOption (long "since"
                          <> help "Since SHA")
+          <*> optional (strOption (long "version"
+                                   <> help "Version for changelog entry"))
 
 runCli :: CLIOpts -> IO ()
 runCli CLIOpts { .. } = do
@@ -50,6 +54,7 @@ runCli CLIOpts { .. } = do
                          & setDeltaParamsOwner cliOwner
                          & setDeltaParamsRepo cliRepo
                          & setDeltaParamsSince cliSince
+                         & setDeltaParamsVersion cliVersion
 
 main :: IO ()
 main = execParser cliOpts >>= runCli

--- a/gh-delta.cabal
+++ b/gh-delta.cabal
@@ -17,9 +17,7 @@ library
   exposed-modules:     Lib
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.11
-                     , file-embed
                      , github
-                     , hastache
                      , syb
                      , text
                      , time

--- a/src/Delta.mustache
+++ b/src/Delta.mustache
@@ -1,5 +1,0 @@
-## {{deltaDate}}
-
-{{#deltaEvents}}
-- {{eventTitle}} - @{{eventAuthor}} {{eventLink}}
-{{/deltaEvents}}

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -10,10 +10,12 @@ module Lib (
     setDeltaParamsOwner,
     setDeltaParamsRepo,
     setDeltaParamsSince,
+    setDeltaParamsVersion,
     ) where
 
 import           Control.Monad    (unless)
 import           Data.Function    ((&))
+import           Data.Maybe       (fromMaybe)
 import           Data.Monoid      ((<>))
 import           Data.String      (fromString)
 import           Data.Text        (Text)
@@ -28,38 +30,43 @@ import qualified GitHub           as GH
 -- | Parameters required to generate a Delta.
 data DeltaParams =
        DeltaParams
-         { deltaAuth  :: Maybe GH.Auth
-         , deltaOwner :: GH.Name GH.Owner
-         , deltaRepo  :: GH.Name GH.Repo
-         , deltaSince :: GH.Name GH.GitCommit
+         { deltaParamsAuth    :: Maybe GH.Auth
+         , deltaParamsOwner   :: GH.Name GH.Owner
+         , deltaParamsRepo    :: GH.Name GH.Repo
+         , deltaParamsSince   :: GH.Name GH.GitCommit
+         , deltaParamsVersion :: Maybe Text
          }
 
 -- | Default params using the gh-delta repo.
 defaultDeltaParams :: DeltaParams
 defaultDeltaParams =
-  DeltaParams Nothing "filib" "gh-delta" "f44caa05adf066ae441cbdbebe54010d94172e9a"
+  DeltaParams Nothing "filib" "gh-delta" "f44caa05adf066ae441cbdbebe54010d94172e9a" Nothing
 
 -- | Setter for personal access token.
 setDeltaParamsAuth :: Maybe String -> DeltaParams -> DeltaParams
-setDeltaParamsAuth x params = params { deltaAuth = fmap (GH.OAuth . fromString) x }
+setDeltaParamsAuth x params = params { deltaParamsAuth = fmap (GH.OAuth . fromString) x }
 
 -- | Setter for owner.
 setDeltaParamsOwner :: String -> DeltaParams -> DeltaParams
-setDeltaParamsOwner x params = params { deltaOwner = fromString x }
+setDeltaParamsOwner x params = params { deltaParamsOwner = fromString x }
 
 -- | Setter for repo.
 setDeltaParamsRepo :: String -> DeltaParams -> DeltaParams
-setDeltaParamsRepo x params = params { deltaRepo = fromString x }
+setDeltaParamsRepo x params = params { deltaParamsRepo = fromString x }
 
 -- | Setter for SHA.
 setDeltaParamsSince :: String -> DeltaParams -> DeltaParams
-setDeltaParamsSince x params = params { deltaSince = fromString x }
+setDeltaParamsSince x params = params { deltaParamsSince = fromString x }
+
+-- | Setter for version.
+setDeltaParamsVersion :: Maybe String -> DeltaParams -> DeltaParams
+setDeltaParamsVersion x params = params { deltaParamsVersion = fmap fromString x }
 
 -- | Single event in a changelog.
 data Event = Event { eventAuthor :: Text, eventTitle :: Text, eventLink :: Text }
 
 -- | Single changelog entry.
-data Delta = Delta { deltaDate :: Text, deltaEvents :: [Event] }
+data Delta = Delta { deltaDate :: Text, deltaEvents :: [Event], deltaVersion :: Maybe Text }
 
 -- | Write changelog entry since SHA to STDOUT.
 generate :: DeltaParams -> IO ()
@@ -70,12 +77,15 @@ generate params@DeltaParams { .. } = do
     Right start -> do
       prs <- closedPullRequestsSince params start
       unless (V.null prs) $
-        T.putStrLn $ template (toDelta start prs)
+        T.putStrLn $ template (toDelta start prs deltaParamsVersion)
 
 -- | Get date a commit was created.
 commitDate :: DeltaParams -> IO (Either GH.Error UTCTime)
 commitDate DeltaParams { .. } = do
-  response <- GH.executeRequestMaybe deltaAuth $ GH.gitCommitR deltaOwner deltaRepo deltaSince
+  response <- GH.executeRequestMaybe deltaParamsAuth $ GH.gitCommitR
+                                                         deltaParamsOwner
+                                                         deltaParamsRepo
+                                                         deltaParamsSince
   case response of
     Left err     -> return $ Left err
     Right commit -> return $ Right (GH.gitUserDate $ GH.gitCommitAuthor commit)
@@ -83,8 +93,8 @@ commitDate DeltaParams { .. } = do
 -- | Get pull requests closed since a given date.
 closedPullRequestsSince :: DeltaParams -> UTCTime -> IO (Vector GH.SimplePullRequest)
 closedPullRequestsSince DeltaParams { .. } since = do
-  response <- GH.executeRequestMaybe deltaAuth $
-                GH.pullRequestsForR deltaOwner deltaRepo opts (Just 100)
+  response <- GH.executeRequestMaybe deltaParamsAuth $
+                GH.pullRequestsForR deltaParamsOwner deltaParamsRepo opts (Just 100)
   case response of
     Left err  -> error $ show err
     Right prs -> return $ V.filter hasSinceBeenMerged prs
@@ -105,20 +115,26 @@ template :: Delta -> Text
 template Delta { .. } = titleTemplate <>
                         newLine <>
                         newLine <>
-                        T.intercalate "\n" (fmap eventTemplate deltaEvents)
+                        T.intercalate newLine (fmap eventTemplate deltaEvents)
   where
     eventTemplate :: Event -> Text
-    eventTemplate Event { .. } = T.intercalate " "
+    eventTemplate Event { .. } = T.intercalate space
                                    ["*", eventTitle, "-", "@" <> eventAuthor, eventLink]
 
     newLine :: Text
     newLine = "\n"
 
+    space :: Text
+    space = " "
+
     titleTemplate :: Text
-    titleTemplate = T.intercalate " " ["##", deltaDate]
+    titleTemplate = T.intercalate space ["##", versionTemplate, deltaDate]
+
+    versionTemplate :: Text
+    versionTemplate = fromMaybe "Unreleased" deltaVersion
 
 -- | Convert collection of pull requests to internal representation.
-toDelta :: UTCTime -> Vector GH.SimplePullRequest -> Delta
+toDelta :: UTCTime -> Vector GH.SimplePullRequest -> Maybe Text -> Delta
 toDelta start prs = Delta date events
   where
     date :: Text


### PR DESCRIPTION
```
[filib@eigg:~/Projects/delta on master]
% gh-delta --owner filib --repo gh-delta --since f44caa05adf066ae441cbdbebe54010d94172e9a --version 0.1.0.0
## 0.1.0.0 2016-05-14

* Refactor to expose setter of datatype - @filib https://github.com/filib/gh-delta/pull/4
* Make it possible to set personal token in ENV - @filib https://github.com/filib/gh-delta/pull/3
* Configure to use PullRequestOptions - @filib https://github.com/filib/gh-delta/pull/2
* Minor cleanup - @filib https://github.com/filib/gh-delta/pull/1
```
