### PR TITLE
Port the tool to a recent GHC and LTS.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,7 @@
 module Main where
 
 import           Control.Applicative ((<|>))
+import           Data.Monoid ((<>))
 import           Data.Function       ((&))
 import qualified Data.Text.IO        as T
 import           Data.Version        (showVersion)
@@ -13,7 +14,7 @@ import           Lib                 (DeltaParams, defaultDeltaParams, generate,
 import           Options.Applicative (Parser, ParserInfo, execParser, fullDesc,
                                       header, help, helper, hidden, info,
                                       infoOption, long, optional, progDesc,
-                                      short, strOption, (<>))
+                                      short, strOption)
 import           Paths_gh_delta      (version)
 import           System.Environment  (lookupEnv)
 import           System.Exit         (die)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -13,7 +13,6 @@ module Lib (
     setDeltaParamsLabel,
     ) where
 
-import           Data.Function    ((&))
 import           Data.Maybe       (fromMaybe)
 import           Data.Monoid      ((<>))
 import           Data.String      (fromString)
@@ -128,15 +127,14 @@ commitDate DeltaParams { .. } sha = do
 closedPullRequestsSince :: DeltaParams -> UTCTime -> UTCTime -> IO (Vector GH.SimplePullRequest)
 closedPullRequestsSince DeltaParams { .. } dateSince dateUntil = do
   response <- GH.executeRequestMaybe deltaParamsAuth $
-                GH.pullRequestsForR deltaParamsOwner deltaParamsRepo opts (Just 100)
+                GH.pullRequestsForR deltaParamsOwner deltaParamsRepo opts (GH.FetchAtLeast 100)
   case response of
     Left err  -> error $ show err
     Right prs -> return $ V.filter hasSinceBeenMerged prs
 
   where
-    opts :: GH.PullRequestOptions
-    opts = GH.defaultPullRequestOptions
-           & GH.setPullRequestOptionsState GH.PullRequestStateClosed
+    opts :: GH.PullRequestMod
+    opts = GH.stateClosed
 
     hasSinceBeenMerged :: GH.SimplePullRequest -> Bool
     hasSinceBeenMerged pr =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,8 @@
-compiler: ghc-7.10.2
-resolver: nightly-2016-05-13
+resolver: lts-11.13
 system-ghc: false
 install-ghc: true
 packages:
 - '.'
-- location:
-    git: git@github.com:iconnect/github.git
-    commit: "06f5112344fce5cba831cc71cdcf7fc5320112c8"
 extra-deps: []
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
@mcfilib This PR ports the tool to use a modern version of GHC and one of the latest versions of `github`. ☮️ 🌱 